### PR TITLE
Fix for S2.FX.Parallel to notify aggregated objects about steps.

### DIFF
--- a/src/effects/parallel.js
+++ b/src/effects/parallel.js
@@ -55,5 +55,15 @@ S2.FX.Parallel = Class.create(S2.FX.Base, {
 
   update: function(position) {
     this.effects.invoke('update', position);
+  },
+
+  cancel: function($super, after) {
+    $super(after);
+    this.effects.invoke('cancel', after);
+  },
+
+  start: function($super) {
+    $super();
+    this.effects.invoke('start');
   }
 });

--- a/src/ui/controls/button.js
+++ b/src/ui/controls/button.js
@@ -231,7 +231,8 @@
       var span = new Element('span', { 'class': 'ui-button-text' });
       // Even an empty text element (e.g., for icon-only buttons) needs to
       // have at least one character of text to force proper alignment.
-      span.update(text || "&nbsp;");
+      // Be careful - UTF-8 character here!
+      span.update(text || " ");
       return span;
     },
     


### PR DESCRIPTION
There is a problem with S2.FX.Parallel that it doesn't invoke methods on aggregated effects like start() or cancel(), so it's callbacks won't be executed. What's more, effects can even not be completed, since cancel() is not called, which causes teardown() to not be called.

I believe those are two methods that have to be called on sub-effects to make them fully functional (start() marks effects as "running" as cancel() won't take any effect if status is not "running") - i don't see any need to call finish() on sub-effects (but if it would be needed, then canel() should not be called - only one of them should be called by parallel aggregator).
