### PR TITLE
Test case for S2.FX.Parallel fix.

### DIFF
--- a/src/ui/controls/button.js
+++ b/src/ui/controls/button.js
@@ -231,7 +231,8 @@
       var span = new Element('span', { 'class': 'ui-button-text' });
       // Even an empty text element (e.g., for icon-only buttons) needs to
       // have at least one character of text to force proper alignment.
-      span.update(text || "&nbsp;");
+      // Be careful - UTF-8 character here!
+      span.update(text || " ");
       return span;
     },
     

--- a/test/unit/effects_test.js
+++ b/test/unit/effects_test.js
@@ -289,6 +289,30 @@ new Test.Unit.Runner({
       });
     });
   }},
+
+  testEffectsParallel: function() { with(this) {
+    var calledStart = false, calledCancel = false;
+
+    var effect = new S2.FX.SlideDown('sandbox');
+    var start = effect.start, cancel = effect.cancel;
+
+    // wrap methods
+    effect.start = function() {
+      calledStart = true;
+      start.call(effect);
+    };
+    effect.cancel = function(after) {
+      calledCancel = true;
+      cancel.call(effect, after);
+    };
+
+    (new S2.FX.Parallel([effect],{ duration:0.75 })).play();
+
+    wait(800, function() {
+      assertEqual(calledStart, true);
+      assertEqual(calledCancel, true);
+    });
+  }},
   
   testElementMorph: function() { with(this) {
     $('error_test_ul').morph('font-size:40px', {duration: 0.75}).setStyle({marginRight:'17px'});


### PR DESCRIPTION
This is the test case for my previous pull request, which was already merged.

Also I include small fix for XHTML compatibility - browsers don't tolerate named entities in innerHTML when page is served as real XHTML (application/xhtml+xml). If you don't like UTF-8 characters inline you can replace it with character entity &#160;.
