### PR TITLE
S2.UI.DIalog improvements

### DIFF
--- a/src/ui/controls/button.js
+++ b/src/ui/controls/button.js
@@ -231,7 +231,8 @@
       var span = new Element('span', { 'class': 'ui-button-text' });
       // Even an empty text element (e.g., for icon-only buttons) needs to
       // have at least one character of text to force proper alignment.
-      span.update(text || "&nbsp;");
+      // Be careful - UTF-8 character here!
+      span.update(text || " ");
       return span;
     },
     

--- a/src/ui/controls/dialog.js
+++ b/src/ui/controls/dialog.js
@@ -415,6 +415,8 @@
     alwaysOnTop: function(alwaysOnTop) {
       if (alwaysOnTop === undefined || alwaysOnTop) ) {
         this.element.addClassName('alwaysOnTop');
+        // make it working from now
+        this.bringToFront();
       } else {
         this.element.removeClassName('alwaysOnTop');
       }

--- a/src/ui/controls/dialog.js
+++ b/src/ui/controls/dialog.js
@@ -202,10 +202,13 @@
 
     /**
      *  S2,UI.Dialog#center() -> this
+     *  S2,UI.Dialog#center(duration) -> this
      *
      *  Moves window to the center of viewport.
+     *
+     *  Parameter is optional and describes effect speed.
     **/
-    center: function() {
+    center: function(duration) {
       // Find the middle of the viewport.
       var vSize = document.viewport.getDimensions();
       var dialog = this.element, layout = dialog.getLayout();
@@ -220,7 +223,7 @@
       position.left += offsets.left;
       position.top  += offsets.top;
 
-      this.moveTo(position.left, position.top);
+      this.moveTo(position.left, position.top, duration);
       return this;
     },
 
@@ -244,7 +247,7 @@
       $(document.body).insert(this);
 
       this.element.show();
-      this.center();
+      this.center(0);
 
       this.focusables = UI.findFocusables(this.element);
 
@@ -416,7 +419,7 @@
      *  while doing bringToFront().
     **/
     alwaysOnTop: function(alwaysOnTop) {
-      if (alwaysOnTop === undefined || alwaysOnTop) ) {
+      if (alwaysOnTop === undefined || alwaysOnTop) {
         this.element.addClassName('alwaysOnTop');
         // make it working from now
         this.bringToFront();
@@ -438,11 +441,14 @@
 
     /**
      *  S2.UI.Dialog#moveTo(left, top) -> this
+     *  S2.UI.Dialog#moveTo(left, top, duration) -> this
      *
      *  Moves window to given position.
+     *
+     *  Thirt parameter is optional and describes effect speed.
     **/
-    moveTo: function(left, top) {
-      this.element.morph('left:' + left + 'px;top:' + top + 'px', { duration: .7 } );
+    moveTo: function(left, top, duration) {
+      this.element.morph('left:' + left + 'px;top:' + top + 'px', { duration: duration === undefined ? .7 : duration } );
       return this;
     }
   });

--- a/src/ui/controls/dialog.js
+++ b/src/ui/controls/dialog.js
@@ -160,6 +160,8 @@
         keypress: this.keypress.bind(this)
       };
 
+      // brings window on top when it's region is clicked
+      this.element.on('click', this.bringToFront.bind(this) );
     },
     
     toElement: function() {
@@ -370,6 +372,34 @@
           (function() { next.focus(); }).defer();
         }
       }
+    },
+
+    /**
+     *  S2.UI.Dialog#bringToFront() -> this
+     *
+     *  Brings dialog on top of display stack.
+     *
+     *  This method ignores elements, that has class ".alwaysOnTop".
+    **/
+    bringToFront: function() {
+      var zIndex = parseInt( this.element.getStyle('zIndex') || 1);
+
+      // searches for the gighest zIndex value
+      // alwaysOnTop - class reserved for further "alwaysOnTop" feature
+      $$('body *:not(.alwaysOnTop)').each( function(element) {
+        var position = element.getStyle('position');
+        if (element !== this && (position == 'absolute' || position == 'fixed')) {
+          var value = parseInt( element.getStyle('zIndex') );
+          if ( !isNaN(value) && value > zIndex) {
+            zIndex = value;
+          }
+        }
+      }.bind(this) );
+
+      // puts window one step higher then current most top.
+      this.element.setStyle( { zIndex: zIndex + 1 } );
+
+      return this;
     }
   });
   

--- a/src/ui/controls/dialog.js
+++ b/src/ui/controls/dialog.js
@@ -400,6 +400,36 @@
       this.element.setStyle( { zIndex: zIndex } );
 
       return this;
+    },
+
+    /**
+     *  S2.UI.Dialog#alwaysOnTop() -> this
+     *  S2.UI.Dialog#alwaysOnTop(flat) -> this
+     *
+     *  Makes window staying always on top (or removes flag if false
+     *  is passed).
+     *
+     *  It means other windows won't calculate this window's zIndex
+     *  while doing bringToFront().
+    **/
+    alwaysOnTop: function(alwaysOnTop) {
+      if (alwaysOnTop === undefined || alwaysOnTop) ) {
+        this.element.addClassName('alwaysOnTop');
+      } else {
+        this.element.removeClassName('alwaysOnTop');
+      }
+
+      return this;
+    },
+
+    /**
+     *  S2.UI.Dialog#isAlwaysOnTop() -> Boolean
+     *
+     *  Checks if window has alwaysOnTop flag set.
+    **/
+    isAlwaysOnTop: function()
+    {
+      return this.element.hasClassName('alwaysOnTop');
     }
   });
   

--- a/src/ui/controls/dialog.js
+++ b/src/ui/controls/dialog.js
@@ -382,22 +382,22 @@
      *  This method ignores elements, that has class ".alwaysOnTop".
     **/
     bringToFront: function() {
-      var zIndex = parseInt( this.element.getStyle('zIndex') || 1);
+      var zIndex = parseInt( this.element.getStyle('zIndex') || 2);
 
       // searches for the gighest zIndex value
       // alwaysOnTop - class reserved for further "alwaysOnTop" feature
       $$('body *:not(.alwaysOnTop)').each( function(element) {
         var position = element.getStyle('position');
-        if (element !== this && (position == 'absolute' || position == 'fixed')) {
+        if (element !== this.element && (position == 'absolute' || position == 'fixed')) {
           var value = parseInt( element.getStyle('zIndex') );
-          if ( !isNaN(value) && value > zIndex) {
-            zIndex = value;
+          if ( !isNaN(value) && value >= zIndex) {
+            zIndex = value + 1;
           }
         }
       }.bind(this) );
 
       // puts window one step higher then current most top.
-      this.element.setStyle( { zIndex: zIndex + 1 } );
+      this.element.setStyle( { zIndex: zIndex } );
 
       return this;
     }

--- a/src/ui/controls/dialog.js
+++ b/src/ui/controls/dialog.js
@@ -440,6 +440,7 @@
     **/
     moveTo: function(left, top) {
       this.element.morph('left:' + left + 'px;top:' + top + 'px', { duration: .7 } );
+      return this;
     },
 
     /**
@@ -457,6 +458,7 @@
 
       // moves window
       this.moveTo(left, top);
+      return this;
     }
   });
   

--- a/src/ui/controls/dialog.js
+++ b/src/ui/controls/dialog.js
@@ -160,6 +160,8 @@
         keypress: this.keypress.bind(this)
       };
 
+      // brings window on top when it's region is clicked
+      this.element.on('click', this.bringToFront.bind(this) );
     },
     
     toElement: function() {
@@ -370,6 +372,34 @@
           (function() { next.focus(); }).defer();
         }
       }
+    },
+
+    /**
+     *  S2.UI.Dialog#bringToFront() -> this
+     *
+     *  Brings dialog on top of display stack.
+     *
+     *  This method ignores elements, that has class ".alwaysOnTop".
+    **/
+    bringToFront: function() {
+      var zIndex = parseInt( this.element.getStyle('zIndex') || 1);
+
+      // searches for the gighest zIndex value
+      // alwaysOnTop - class reserved for further "alwaysOnTop" feature
+      $$('*:not(.alwaysOnTop)').each( function(element) {
+        var display = element.getStyle('display');
+        if (element !== this && display == 'absolute' || display == 'fixed') {
+          var value = parseInt( element.getStyle('zIndex') );
+          if ( !isNaN(value) && value > zIndex) {
+            zIndex = value;
+          }
+        }
+      }.bind(this) );
+
+      // puts window one step higher then current most top.
+      this.element.setStyle( { zIndex: zIndex + 1 } );
+
+      return this;
     }
   });
   

--- a/src/ui/controls/dialog.js
+++ b/src/ui/controls/dialog.js
@@ -427,9 +427,34 @@
      *
      *  Checks if window has alwaysOnTop flag set.
     **/
-    isAlwaysOnTop: function()
-    {
+    isAlwaysOnTop: function() {
       return this.element.hasClassName('alwaysOnTop');
+    },
+
+    /**
+     *  S2.UI.Dialog#moveTo(left, top) -> this
+     *
+     *  Moves window to given position.
+    **/
+    moveTo: function(left, top) {
+      this.element.morph('left:' + left + 'px;top:' + top + 'px', { duration: .7 } );
+    },
+
+    /**
+     *  S2,UI.Dialog#center() -> this
+     *
+     *  Moves window to the center of viewport.
+    **/
+    center: function() {
+      var layout = this.element.getLayout();
+      var viewport = document.viewport.getDimensions();
+
+      // calculates coordinates
+      var left = viewport.width / 2 - layout.get('width') / 2;
+      var top = viewport.height / 2 - layout.get('height') / 2;
+
+      // moves window
+      this.moveTo(left, top);
     }
   });
   

--- a/src/ui/controls/dialog.js
+++ b/src/ui/controls/dialog.js
@@ -200,7 +200,12 @@
       this.element.insert(this.buttonPane);
     },
 
-    _position: function() {
+    /**
+     *  S2,UI.Dialog#center() -> this
+     *
+     *  Moves window to the center of viewport.
+    **/
+    center: function() {
       // Find the middle of the viewport.
       var vSize = document.viewport.getDimensions();
       var dialog = this.element, layout = dialog.getLayout();
@@ -215,10 +220,8 @@
       position.left += offsets.left;
       position.top  += offsets.top;
 
-      this.element.setStyle({
-        left: position.left + 'px',
-        top:  position.top  + 'px'
-      });
+      this.moveTo(position.left, position.top);
+      return this;
     },
 
     /**
@@ -241,7 +244,7 @@
       $(document.body).insert(this);
 
       this.element.show();
-      this._position();
+      this.center();
 
       this.focusables = UI.findFocusables(this.element);
 
@@ -440,24 +443,6 @@
     **/
     moveTo: function(left, top) {
       this.element.morph('left:' + left + 'px;top:' + top + 'px', { duration: .7 } );
-      return this;
-    },
-
-    /**
-     *  S2,UI.Dialog#center() -> this
-     *
-     *  Moves window to the center of viewport.
-    **/
-    center: function() {
-      var layout = this.element.getLayout();
-      var viewport = document.viewport.getDimensions();
-
-      // calculates coordinates
-      var left = viewport.width / 2 - layout.get('width') / 2;
-      var top = viewport.height / 2 - layout.get('height') / 2;
-
-      // moves window
-      this.moveTo(left, top);
       return this;
     }
   });

--- a/test/functional/controls_dialog.html
+++ b/test/functional/controls_dialog.html
@@ -143,7 +143,7 @@
   
   
   <!-- DIALOG 2 -->
-  <h2>Dialog with custom content & buttons</h2>
+  <h2>Dialog with custom content &amp; buttons</h2>
   
   <div class="ui-widget ui-button-container">
 
@@ -197,6 +197,68 @@
       <li>The <code>OK</code> button <strong>should</strong> receive focus when the dialog opens. Pressing <kbd>SPACE</kbd> or <kbd>ENTER</kbd> <strong>should</strong> press whatever button is in focus.</li>
       <li>If the dialog has a visible "close" button, <em>three controls</em> <strong>should</strong> be eligible for keyboard focus: the <code>OK</code> button, the <code>Cancel</code> button, and the dialog's "close" button. Pressing <kbd>TAB</kbd> repeatedly should cycle through these three buttons (without focusing any elements underneath the modal layer). Pressing <kbd>SHIFT + TAB</kbd> should follow the same cycle in reverse.</li>
       <li>If the dialog's close button is not visibile, it <strong>should not</strong> be focusable, even though it's still in the HTML. Confirm that pressing <kbd>TAB</kbd> cycles between the two buttons and nothing else.</li>
+    </ul>
+  </div> <!-- .description -->
+  
+  
+  <!-- DIALOG 3 -->
+  <h2>Dialog display management</h2>
+  
+  <div class="ui-widget ui-button-container">
+
+    <button id="dialog_link3">Open Dialog</button>
+  
+    <script type="text/javascript">
+     new S2.UI.Button('dialog_link3', {
+       icons: { primary: 'ui-icon-newwin' }
+     });
+     
+     $('dialog_link3').observe('click', function(event) {
+        event.stop();
+        var dialog;
+
+        var switcher = (new Element("label"))
+          .insert(
+            new Element("input", {type: "checkbox"})
+              .observe("click", function() {
+                dialog.alwaysOnTop(this.checked);
+              } )
+          )
+          .insert(" always on top");
+
+        dialog = new S2.UI.Dialog({
+          modal: false,
+          buttons: [
+            {
+              label: 'Center me',
+              action: function(instance) {
+                instance.center();
+              }
+            },
+            {
+              label: 'Move me to 10x10',
+              action: function(instance) {
+                instance.moveTo(10, 10);
+              }
+            }
+          ],
+          content: (new Element('div'))
+            .insert(switcher)
+        });
+        dialog.open();
+     });
+    </script>
+    
+  </div> <!-- .ui-widget -->
+  
+  <div class="description">
+    <p>A non-modal dialog, that you can use as a simple window.</p>
+    
+    <ul>
+      <li>You can set <strong>alwaysOnTop</strong> with <code>.alwaysOnTop()</code>, so it will not be covered by other windows.</li>
+      <li>You can bring dialog on top of display stack (except <strong>alwaysOnTop</strong> fallged dialogs) by clicking in a region of a dialog (also programaticaly using <code>.bringToFront()</code> method).</li>
+      <li>You can move dialog programaticaly using <code>.moveTo(x, y)</code>.</li>
+      <li>You can center dialog on a screen programaticaly using <code>.center()</code>.</li>
     </ul>
   </div> <!-- .description -->
   


### PR DESCRIPTION
Implemented various additional methods:
- moveTo(x, y[, duration]) - moves dialog to given position.
- center([duration]) - it's _position() method renamed for public API.
- alwaysOnTop([flag]) - makes dialog window staying always over other dialogs.
- bringToFront() - brings dialog window on top of display stack (except windows with alwaysOnTop flag set).

Unfortunately my XHTML fix is in my master, it is already in different pull request.
