### PR TITLE
S2.UI.Dialog title handling and collapsing/expanding + fluent interface fixes.

### DIFF
--- a/src/ui/controls/button.js
+++ b/src/ui/controls/button.js
@@ -103,13 +103,14 @@
     setEnabled: function(shouldBeEnabled) {
       var element = this.toElement();
       
-      if (this.enabled === shouldBeEnabled) return;
+      if (this.enabled === shouldBeEnabled) return this;
       this.enabled = shouldBeEnabled;
 
       if (shouldBeEnabled) element.removeClassName('ui-state-disabled');
       else element.addClassName('ui-state-disabled');
       
       this.element.disabled = !shouldBeEnabled;
+      return this;
     },
     
     toElement: function() {

--- a/src/ui/controls/button.js
+++ b/src/ui/controls/button.js
@@ -231,7 +231,8 @@
       var span = new Element('span', { 'class': 'ui-button-text' });
       // Even an empty text element (e.g., for icon-only buttons) needs to
       // have at least one character of text to force proper alignment.
-      span.update(text || "&nbsp;");
+      // Be careful - UTF-8 character here!
+      span.update(text || " ");
       return span;
     },
     

--- a/src/ui/controls/dialog.js
+++ b/src/ui/controls/dialog.js
@@ -134,8 +134,9 @@
       // this.closeButton.insert(this.closeText);
 
   	  // Text for title bar.
+      this.title = this.options.title;
   	  this.titleText = new Element('span', { 'class': 'ui-dialog-title' });
-  	  this.titleText.update(this.options.title).identify();
+  	  this.titleText.update(this.title).identify();
   	  // This is the label for ARIA.	  
   	  this.element.writeAttribute('aria-labelledby',
   	   this.titleText.readAttribute('id'));
@@ -370,6 +371,30 @@
           (function() { next.focus(); }).defer();
         }
       }
+    },
+
+    /**
+     *  S2.UI.Dialog#getTitle() -> String
+     *
+     *  Returns current dialog title.
+    **/
+    getTitle: function()
+    {
+      return this.title;
+    },
+
+    /**
+     *  S2.UI.Dialog#setTitle(title) -> this
+     *  - title (String): New dialog title.
+     *
+     *  Changes dialog title.
+    **/
+    setTitle: function(title)
+    {
+      this.title = title;
+      this.titleText.update(this.title);
+
+      return this;
     }
   });
   

--- a/src/ui/controls/dialog.js
+++ b/src/ui/controls/dialog.js
@@ -51,7 +51,16 @@
    *    that tells whether the dialog was closed in success. The `form`
    *    property (present if the dialog's content contained a `FORM` element)
    *    holds an `Object` serialization of the form's content.
-   *
+   *  * `ui:dialog:before:collapse`: Fired when the dialog is told to collapse,
+   *    but before the effect is fired. **Cancelable**. If cancelled,
+   *    will leave dialog as it is.
+   *  * `ui:dialog:after:collapse`: Fired just after the dialog is collapsed
+   *    (when the effect is finished). Cannot be cancelled.
+   *  * `ui:dialog:before:expand`: Fired when the dialog is told to expand,
+   *    but before the effect is fired. **Cancelable**. If cancelled,
+   *    will leave dialog as it is.
+   *  * `ui:dialog:after:expand`: Fired just after the dialog is expanded
+   *    (when the effect is finished). Cannot be cancelled.
   **/
   UI.Dialog = Class.create(UI.Base, UI.Mixin.Element, {
     NAME: "S2.UI.Dialog",

--- a/src/ui/controls/menu.js
+++ b/src/ui/controls/menu.js
@@ -153,7 +153,7 @@
       }
       
       UI.removeClassNames(this.choices, 'ui-state-active');
-      if (index === -1) return;
+      if (index === -1) return this;
       this.choices[index].addClassName('ui-state-active');
       this._highlightedIndex = index;
       
@@ -161,6 +161,8 @@
       var active = this.element.down('#' + this.activeId);
       if (active) active.writeAttribute('id', '');
       this.choices[index].writeAttribute('id', this.activeId);
+
+      return this;
     },
     
     /**
@@ -222,6 +224,8 @@
       }
       
       this.element.fire('ui:menu:after:open', { instance: this });
+
+      return this;
     },
     
     /**

--- a/src/ui/controls/slider.js
+++ b/src/ui/controls/slider.js
@@ -251,6 +251,7 @@
       this._saveValues();
       this._setValue(sliderValue, handleIndex);
       this._fireChangedEvent();
+      return  this;
     },
     
     _setValue: function(sliderValue, handleIndex) {
@@ -521,7 +522,7 @@
      *  so attempts to cancel the event will be ignored.
     **/
     undo: function() {
-      if (!this._oldValues) return;
+      if (!this._oldValues) return this;
       this._restoreValues();
     
       this.undoing = true;
@@ -529,6 +530,7 @@
       this.undoing = false;
       
       this._fireChangedEvent();
+      return this;
     },
     
     // Set the current values as the values that will be restored after a

--- a/test/functional/controls_dialog.html
+++ b/test/functional/controls_dialog.html
@@ -143,7 +143,7 @@
   
   
   <!-- DIALOG 2 -->
-  <h2>Dialog with custom content & buttons</h2>
+  <h2>Dialog with custom content &amp; buttons</h2>
   
   <div class="ui-widget ui-button-container">
 
@@ -199,6 +199,54 @@
       <li>If the dialog's close button is not visibile, it <strong>should not</strong> be focusable, even though it's still in the HTML. Confirm that pressing <kbd>TAB</kbd> cycles between the two buttons and nothing else.</li>
     </ul>
   </div> <!-- .description -->
+
+  <!-- DIALOG 4 -->
+  <h2>Dialog runtime modifications</h2>
   
+  <div class="ui-widget ui-button-container">
+
+    <button id="dialog_link4">Open Dialog</button>
+  
+    <script type="text/javascript">
+     new S2.UI.Button('dialog_link4', {
+       icons: { primary: 'ui-icon-newwin' }
+     });
+
+     var dialog4 = new S2.UI.Dialog({
+       modal: false
+     });
+
+     $('dialog_link4').observe('click', function(event) {
+        event.stop();
+        dialog4.open();
+     });
+    </script>
+    
+  </div> <!-- .ui-widget -->
+  
+  <div class="description">
+    <p>Following buttons allows you to handle dialog properties at runtime. Before using this demo functionality, you have to open dialog with the button above.</p>
+
+    <h3><code>.getTitle()</code>/<code>.setTitle()</code></h3>
+
+    <p>
+      <button id="dialog4_title_getter">Show title</button>
+      <button id="dialog4_title_setter">Change title</button>
+    </p>
+
+    <script type="text/javascript">
+     $('dialog4_title_getter').observe('click', function(event) {
+        event.stop();
+        alert( dialog4.getTitle() );
+     });
+
+     $('dialog4_title_setter').observe('click', function(event) {
+        event.stop();
+        dialog4.setTitle( prompt('Type new title') );
+     });
+    </script>
+  </div> <!-- .description -->
+  
+
 </body>
 </html>

--- a/test/functional/controls_dialog.html
+++ b/test/functional/controls_dialog.html
@@ -245,8 +245,34 @@
         dialog4.setTitle( prompt('Type new title') );
      });
     </script>
+
+    <h3><code>.collapse()</code>/<code>.expand()</code>/<code>.toggle()</code></h3>
+
+    <p>
+      <button id="dialog4_toggle_collapse">Collapse</button>
+      <button id="dialog4_toggle_expand">Expand</button>
+      <button id="dialog4_toggle_toggle">Toggle</button>
+    </p>
+
+    <script type="text/javascript">
+     $('dialog4_toggle_collapse').observe('click', function(event) {
+        event.stop();
+        dialog4.collapse();
+     });
+
+     $('dialog4_toggle_expand').observe('click', function(event) {
+        event.stop();
+        dialog4.expand();
+     });
+
+     $('dialog4_toggle_toggle').observe('click', function(event) {
+        event.stop();
+        dialog4.toggle();
+     });
+    </script>
+
+    <p>Toggling effect is also bound to title bar double-click event.</p>
   </div> <!-- .description -->
-  
 
 </body>
 </html>


### PR DESCRIPTION
Collapse/expand feature for S2.UI.Dialog class:
- collapsing (rolling up to title bar),
- expanding (un-rolling collapsed window),
- toggling state.

It's possible to pass own effects settings as options. There are after: and before: events for both actions (before: event handlers can cancel action).

The only problem is with the possible icon on title bar fot that. I created an issue #30 about that. At the moment actions can be called from API, or triggered by double-click on title bar of dialog.

This commit also contains fixes for S2.UI.\* classes for methods, that should return `this`. In some places `return` was ommited, in other there was just `return` without `this`. I fixed that in places found by:

grep " -> this" src/ -R

So if there were some undocumented methods that should work this way, or documented different way, I didn't looked for them.

Also added .setTitle(title)/.getTitle() methods, which allow runtime title access.
