### PR TITLE
Fixed problem with global reference to S2 namespace.

### DIFF
--- a/src/ui/mixin/element.js
+++ b/src/ui/mixin/element.js
@@ -35,6 +35,6 @@
     this.__observers.push(result);
   };
   
-  window.S2.UI.Mixin.Element = E;  
+  S2.UI.Mixin.Element = E;  
 })();
 


### PR DESCRIPTION
Reference to `window.S2` is problematic, when you enclose Scripty2 within closure for minifying.
